### PR TITLE
Addressing issue with date values < 1900

### DIFF
--- a/netcdfbrowserdialog.py
+++ b/netcdfbrowserdialog.py
@@ -404,7 +404,7 @@ class NetCDFBrowserDialog(QDialog):
                             self.dim_values2[ dim ] = []
                             only_days = True
                             for date in dates:
-                                val = date.strftime("%Y-%m-%d %H:%M:%S")
+                                val = date.isoformat(" ") # equivalent to strftime("%Y-%m-%d %H:%M:%S")
                                 if not val.endswith(" 00:00:00"):
                                     only_days = False
                                 self.dim_values2[ dim ].append(val)


### PR DESCRIPTION
Addressing #1. A very simple change. With a few sample NetCDF datasets, I have tested that this breaks nothing. The test datasets included datasets with dates both before and after 1900, and only after 1900.
